### PR TITLE
[UI] 게임 메뉴 선택화면에서 키 안먹는 문제 해결

### DIFF
--- a/src/main/java/org/teamseven/tetris/Pipeline.java
+++ b/src/main/java/org/teamseven/tetris/Pipeline.java
@@ -23,5 +23,6 @@ public class Pipeline {
         container.add(component);
         container.revalidate();
         container.repaint();
+        container.requestFocus();
     }
 }

--- a/src/main/java/org/teamseven/tetris/ui/TetrisPane.java
+++ b/src/main/java/org/teamseven/tetris/ui/TetrisPane.java
@@ -206,8 +206,7 @@ public class TetrisPane extends JLayeredPane implements IDesign, KeyListener {
 
     @Override
     public void setAction() {
-        this.setFocusable(true);
-        this.requestFocusInWindow();
+        this.requestFocus();
         addKeyListener(this);
     }
 


### PR DESCRIPTION
생각보다 간편하게 해결됨
컨테이너 내용을 바꿀때 마다 requestFocus 메서드 호출하니까 해결 됨.